### PR TITLE
Update demo to allow characters from International Phonetic Alphabet

### DIFF
--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -200,15 +200,6 @@ $(document).ready(function() {
       return false;
     });
 
-    /**
-     * Check that the text doesn't contains non latin-1 characters.
-     * @param  String  The string to test
-     * @return true if the string is latin-1
-     */
-    function containsAllLatin1(str) {
-      return  /^[A-z\u00C0-\u00ff\s?@¿''"<>\.,-\/#!$%\^&\*;:{}=\-_`~()0-9]+$/.test(str);
-    }
-
     function validText(voice, text) {
       $('.error-row').css('visibility','hidden');
       $('.errorMsg').text('');
@@ -219,10 +210,6 @@ $(document).ready(function() {
         return false;
       }
 
-      if (!containsAllLatin1(text)) {
-        showError('Language not supported. Please use only ISO 8859 characters');
-        return false;
-      }
       return true;
     }
   }


### PR DESCRIPTION
I removed the check that forces the text to only be latin; characters from the IPA can't all be checked , they are simply too many.