### PR TITLE
Add check on text tab

### DIFF
--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -187,12 +187,12 @@ export default class Demo extends Component {
 
   downloadAllowed() {
     const {
-      ssml, ssml_voice, current_tab,
+      ssml, ssml_voice, current_tab, text,
     } = this.state;
     return (
       (ssml_voice && current_tab === 2)
       || (ssml && current_tab === 1)
-      || (current_tab === 0)
+      || (current_tab === 0 && text)
     );
   }
 


### PR DESCRIPTION
Disables download and speak button when the textarea in the Text tab is empty.
(reported here https://twitter.com/_chrisisler/status/1016114092023656451)