### PR TITLE
Feat/streaming audio playback

### DIFF
--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -83,6 +83,13 @@ export default class Demo extends Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.audioElementRef.current) {
+      this.audioElementRef.current.removeEventListener('play', this.onAudioLoaded);
+      this.audioElementRef.current.removeEventListener('error', this.handleAudioError);
+    }
+  }
+
   onTabChange(idx) {
     this.setState({ current_tab: idx });
   }

--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -73,11 +73,13 @@ export default class Demo extends Component {
     this.downloadDisabled = this.downloadDisabled.bind(this);
     this.speakDisabled = this.speakDisabled.bind(this);
     this.downloadAllowed = this.downloadAllowed.bind(this);
+    this.handleAudioError = this.handleAudioError.bind(this);
   }
 
   componentDidMount() {
     if (this.audioElementRef.current) {
       this.audioElementRef.current.addEventListener('play', this.onAudioLoaded);
+      this.audioElementRef.current.addEventListener('error', this.handleAudioError);
     }
   }
 
@@ -172,6 +174,12 @@ export default class Demo extends Component {
     }
     console.log(JSON.stringify(params));
     return params;
+  }
+
+  handleAudioError(error) {
+    console.error(error);
+    this.setState({ error: { error: 'Could not play audio' }, loading: false });
+    setTimeout(() => this.setState({ error: null }), 5000);
   }
 
   downloadDisabled() {


### PR DESCRIPTION
This uses the `<audio>` element to stream audio directly from the backend. It saves time vs. waiting for the entire audio blob to buffer and then starting playback.